### PR TITLE
fix: resolve angular warning using target es2015

### DIFF
--- a/packages/elf-sync-state/tsconfig.json
+++ b/packages/elf-sync-state/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/packages/elf-sync-state/tsconfig.spec.json
+++ b/packages/elf-sync-state/tsconfig.spec.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
+    "target": "ES2015",
     "types": ["jest", "node"]
   },
   "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]


### PR DESCRIPTION
## Fix angular CommonJS or AMD dependencies warning

When running this package, angular would provide the following warning:

```
Warning: .\auth\data\src\lib\auth.repository.ts depends on 'elf-sync-state'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
```

The tsconfig stored in the packages directory was misconfigured.
After moving the property `"module": "commonjs"` to the tsconfig.spec.json file, angular no longer complained about CommonJS dependencies.